### PR TITLE
fix: Use Vite asset import for Mario sprite to fix production 404 error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/mario-js/issues/12
-Your prepared branch: issue-12-c9477b624503
-Your prepared working directory: /tmp/gh-issue-solver-1765483408726
-Your forked repository: konard/andchir-mario-js
-Original repository (upstream): andchir/mario-js
-
-Proceed.


### PR DESCRIPTION
## 🎯 Summary

This PR fixes the production deployment error where the Mario sprite image was returning a 404 error:
```
GET https://andchir.github.io/mario-js/src/media/sprite_mario.png 404 (Not Found)
```

## 🔍 Root Cause

The issue was in `src/scenes/PreloadScene.js:10` where the sprite was loaded using a string literal path:
```javascript
this.load.spritesheet('mario', 'src/media/sprite_mario.png', { ... });
```

This approach worked in development but failed in production because:
- Vite doesn't process string literal paths as bundled assets
- The file wasn't copied to the `dist` directory during build
- The path didn't account for the configured base URL (`/mario-js/`)

## ✅ Solution

Changed to use Vite's asset import system by importing the sprite as a module:
```javascript
import marioSpriteUrl from '../media/sprite_mario.png';

// Later in preload():
this.load.spritesheet('mario', marioSpriteUrl, { ... });
```

This ensures Vite properly processes the asset:
- ✅ Includes the sprite in the build output (`dist/assets/sprite_mario-[hash].png`)
- ✅ Generates a proper URL with content hash for cache-busting
- ✅ Automatically handles the base path configuration

## 🧪 Testing

Verified the fix by building locally:
```bash
NODE_ENV=production npm run build
```

Build output confirms proper asset handling:
```
dist/assets/sprite_mario-B5KjDIb9.png     45.75 kB
```

## 📝 Changes

- Modified `src/scenes/PreloadScene.js` to import the sprite image as a module

## 📚 Reference

- Fixes #12
- Related Vite documentation: [Static Asset Handling](https://vitejs.dev/guide/assets.html)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)