### PR TITLE
Исправить использование спрайта увеличенного разрешения

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,15 +53,3 @@ Original repository (upstream): andchir/mario-js
 Proceed.
 
 Run timestamp: 2025-12-11T22:58:53.971Z
-
----
-
-Issue to solve: https://github.com/andchir/mario-js/issues/47
-Your prepared branch: issue-47-8573e93f5941
-Your prepared working directory: /tmp/gh-issue-solver-1765531466193
-Your forked repository: konard/andchir-mario-js
-Original repository (upstream): andchir/mario-js
-
-Proceed.
-
-Run timestamp: 2025-12-12T09:24:30.661Z


### PR DESCRIPTION
## Summary

Fixes sprite frame dimensions to match the doubled resolution sprite sheet.

The sprite `sprite_mario.png` was updated to 2x resolution (256×160 instead of 128×80) in commit fc7252a. This PR updates the sprite sheet frame dimensions in PreloadScene.js to correctly extract individual frames from the higher resolution sprite:
- `frameWidth`: 32 → 64 (doubled)
- `frameHeight`: 40 → 80 (doubled)

## Changes
- Updated `src/scenes/PreloadScene.js`: Changed sprite frame dimensions from 32×40 to 64×80

## Test plan
- [x] Build succeeds without errors
- [x] Dev server starts successfully
- [ ] Visual verification: Mario sprite displays correctly in-game
- [ ] All animations work properly with the new frame dimensions

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)