### PR TITLE
Fix Mario animation on moving platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,15 +65,3 @@ Original repository (upstream): andchir/mario-js
 Proceed.
 
 Run timestamp: 2025-12-12T10:39:55.086Z
-
----
-
-Issue to solve: https://github.com/andchir/mario-js/issues/72
-Your prepared branch: issue-72-f2cfc2d03d64
-Your prepared working directory: /tmp/gh-issue-solver-1765637389059
-Your forked repository: konard/andchir-mario-js
-Original repository (upstream): andchir/mario-js
-
-Proceed.
-
-Run timestamp: 2025-12-13T14:49:53.735Z


### PR DESCRIPTION
## Summary

- Fixed the walking animation playing incorrectly when Mario stands still on a moving platform
- Changed animation logic from checking `body.velocity.x !== 0` to checking if movement keys are actively pressed
- This ensures the idle animation is shown when standing still, even on a moving platform

## Root Cause

When Mario stands on a moving platform, `handleMovement()` sets his velocity to inherit the platform's velocity (`platformVelocityX`). The original animation logic in `updateAnimation()` checked `this.body.velocity.x !== 0` to determine if the walking animation should play, which was true even when Mario wasn't pressing any movement keys.

## Fix

Changed the animation check from:
```javascript
} else if (this.body.velocity.x !== 0) {
```
to:
```javascript
const isMoving = this.cursors.left.isDown || this.cursors.right.isDown;
// ...
} else if (isMoving) {
```

This ensures the walking animation only plays when the player is actively pressing movement keys.

## Test Plan

- [ ] Jump on a moving platform without pressing any movement keys - Mario should show idle animation
- [ ] Walk on a moving platform by pressing left/right keys - Mario should show walking animation
- [ ] Walking animation should still work correctly on static ground
- [ ] Build passes (`npm run build`)

Fixes andchir/mario-js#72

🤖 Generated with [Claude Code](https://claude.com/claude-code)