### PR TITLE
Sync package-lock.json to fix deployment error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,15 +65,3 @@ Original repository (upstream): andchir/mario-js
 Proceed.
 
 Run timestamp: 2025-12-12T10:39:55.086Z
-
----
-
-Issue to solve: https://github.com/andchir/mario-js/issues/89
-Your prepared branch: issue-89-5aa5b9924653
-Your prepared working directory: /tmp/gh-issue-solver-1765648266265
-Your forked repository: konard/andchir-mario-js
-Original repository (upstream): andchir/mario-js
-
-Proceed.
-
-Run timestamp: 2025-12-13T17:51:10.884Z


### PR DESCRIPTION
## Summary

Fixes the CI deployment error where `npm ci` fails due to package-lock.json being out of sync with package.json.

## Problem / Проблема

The deployment was failing with the following error:
```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error Missing: concurrently@8.2.2 from lock file
npm error Missing: electron@28.3.3 from lock file
npm error Missing: electron-builder@24.13.3 from lock file
npm error Missing: wait-on@7.2.0 from lock file
...
```

## Root Cause / Причина

The `package-lock.json` was outdated and missing entries for devDependencies that were added in package.json:
- `concurrently@^8.2.2`
- `electron@^28.0.0`
- `electron-builder@^24.9.1`
- `wait-on@^7.2.0`

## Solution / Решение

Regenerated `package-lock.json` by running `npm install` to synchronize it with `package.json`. The lock file grew from 1079 lines to 5361 lines, including all the required dependencies.

## Test Plan

- [x] Verified `npm ci` works locally after the fix
- [x] No other code changes required

## References

Fixes andchir/mario-js#89

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>